### PR TITLE
autoprefixer-loader@1.2.0 报错：process() method is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "SPM project bundler based on webpack.",
   "dependencies": {
     "atpl-loader": "~0.1.0",
-    "autoprefixer-loader": "~1.2.0",
+    "autoprefixer-loader": "~2.0.0",
     "babel-core": "~5.4.0",
     "babel-loader": "~5.2.0",
     "browser-resolve": "~1.9.0",


### PR DESCRIPTION
这里：[https://github.com/passy/autoprefixer-loader/issues/20](https://github.com/passy/autoprefixer-loader/issues/20)，需升级到2.0.0
