### PR TITLE
chore: add source-map for build and fix woof2 do not support loader

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -26,6 +26,7 @@ program
   .option('--progress', 'show progress')
   .option('--no-color', 'disable colorful print')
   .option('--no-install', 'disable install')
+  .option('--sourcemap', 'enable sourcemap for build')
   .parse(process.argv);
 
 log.config(program);
@@ -68,7 +69,9 @@ var args = {
   noInstall: !program.install,
 
   debug: program.debug,
-  progress: program.progress
+  progress: program.progress,
+
+  sourcemap: program.sourcemap
 };
 
 if (entry && entry.length) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -174,7 +174,7 @@ function getWebpackOpts(opts, callback) {
         { test: /\.handlebars$/, loader: normalize('handlebars?helperDirs[]=' + __dirname + '/../helpers', opts, 'handlebars') },
         { test: /\.css$/, loader: cssLoader },
         { test: /\.less$/, loader: lessLoader },
-        { test: /\.(png|jpe?g|gif|eot|svg|ttf|woff)$/, loader: loader }
+        { test: /\.(png|jpe?g|gif|eot|svg|ttf|woff|woff2)$/, loader: loader }
       ]
     },
     plugins: [
@@ -197,6 +197,11 @@ function getWebpackOpts(opts, callback) {
 
   args.files = files;
   args.entry = files.js;
+
+  if (opts.build.sourcemap) {
+    args.devtool = '#source-map';
+    opts.build.debug || (opts.build.uglify.sourceMap = true);
+  }
 
   if (opts.build.umd) {
     args.output.library = opts.build.umd;


### PR DESCRIPTION
1. `spm build` 新增`sourcemap`参数
2. 解决 `woof2` 字体不被loader加载
