### PR TITLE
修复npm3中loaders找不到的bug

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -184,6 +184,11 @@ function getWebpackOpts(opts, callback) {
       new FixCSSPathPlugin(opts.build.debug)
     ]
   };
+  // Fix: loaders not found in npm3
+  var spmPath = join(__dirname, '../..');
+  if (~spmPath.indexOf('spm')) {
+    args.resolveLoader.modulesDirectories.push(spmPath);
+  }
 
   if (opts.build.extractCSS || files.extractCSS) {
     args.plugins.push(new ExtractTextPlugin(name + '.css', {


### PR DESCRIPTION
修复在npm3中loaders被移到了spm的node_modules中，在spm-webpack的module里找不到的bug。
